### PR TITLE
Fix PI cannot be used for classification models.

### DIFF
--- a/explainers/pi/pi.py
+++ b/explainers/pi/pi.py
@@ -28,22 +28,19 @@ def permutation_importance(estimator,feature_names=None,plot=True,save=True,save
 
     return pi
 
-def permutation_importance_xai(m,f,x,y,rmse,plot=True,save=True,save_path='pi.jpg'):#x是训练集的,y是对应的
-    result=[]
-    for feauture in f:
-        x_scramble=x.copy()
-        x_scramble[feauture]=x[feauture].sample(frac=1).values
-        from sklearn.metrics import mean_squared_error
-        y_scramble=m.predict(x_scramble)
-        rmse_scramble=mean_squared_error(y_scramble, y)
-        result.append({'feature':feauture,'pi':abs(rmse-rmse_scramble)})
-    # result_df=pd.DataFrame(result).sort_values(by='pi',ascending=True)
+def permutation_importance_xai(m,f,x,y, plot=True,save=True,save_path='pi.jpg', seed=None):#x是训练集的,y是对应的
+    result={}
+    from sklearn.inspection import permutation_importance
+    i = permutation_importance(m, x, y, random_state=seed)
+    result['feature'] = f
+    result['pi'] = i.importances_mean
     result_df = pd.DataFrame(result)
+    result_df = result_df.sort_values(by='pi', ascending=False)
     print(result_df)
 
     import matplotlib.pyplot as plt
     fig = plt.figure()
-    plt.barh(result_df['feature'],result_df['pi'])
+    plt.barh(result_df['feature'][::-1],result_df['pi'][::-1])
     plt.title('Permutation Feature Importance')
 
 

--- a/explainers/pi/pi.py
+++ b/explainers/pi/pi.py
@@ -28,10 +28,10 @@ def permutation_importance(estimator,feature_names=None,plot=True,save=True,save
 
     return pi
 
-def permutation_importance_xai(m,f,x,y, plot=True,save=True,save_path='pi.jpg', seed=None):#x是训练集的,y是对应的
+def permutation_importance_xai(m,f,x,y, plot=True,save=True,save_path='pi.jpg', seed=None, n_repeats=5):#x是训练集的,y是对应的
     result={}
     from sklearn.inspection import permutation_importance
-    i = permutation_importance(m, x, y, random_state=seed)
+    i = permutation_importance(m, x, y, random_state=seed, n_repeats=n_repeats)
     result['feature'] = f
     result['pi'] = i.importances_mean
     result_df = pd.DataFrame(result)


### PR DESCRIPTION
rmse doesn't work for classification models, so we'll use sklearn's built-in permutation_importance instead, averaging over multiple shuffles (default 5), sorting the plots from highest to lowest importance, and increasing the seed